### PR TITLE
Add deploy configuration; use gulp dev locally

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,11 @@
 const gulp = require('gulp');
 const browserSync = require('browser-sync').create();
+const argv = require('yargs').argv
+const isProduction = argv.production
 
-browserSync.init({ server: '.' });
+gulp.task('server', () => {
+  browserSync.init({ server: '.', open: !isProduction});
+})
 
 gulp.task('watch', function() {
   return gulp.watch('*.(html|css|js)', (done) => {
@@ -10,6 +14,7 @@ gulp.task('watch', function() {
     })
 });
 
-gulp.task('server', gulp.series([
+gulp.task('dev', gulp.series([
+  'server',
   'watch',
 ]));

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "server": "gulp server"
+    "server": "gulp dev"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
We want to deploy our application using the `gulp watch` command,
but Netlify deploys fail when trying to open a browser window. Since we
can open localhost:3000 manually, we don't need to automatically open a
browser window on starting the server.