### PR TITLE
Set default language to English

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
 
 <head>
   <link href="https://fonts.googleapis.com/css?family=Heebo:900|Montserrat&display=swap" rel="stylesheet">


### PR DESCRIPTION
Let's set the default language to English, this stops the Google
translation prompt from popping up on the home page.